### PR TITLE
Support for non-mono build containers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -59,13 +59,13 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ inputs.release_image }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Mono Docker images to Github
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build and Release Mono Docker images to Dockerhub
         if: ${{ inputs.release_image }}
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,8 +124,8 @@ jobs:
       - name: Collect outputs
         id: collect_outputs
         run: |
-          echo github_image_name_and_tag=ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
-          echo image_name_and_tag=${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
+          echo github_image_name_and_tag=ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
+          echo image_name_and_tag=${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
     outputs:
       github_image_name_and_tag: ${{ steps.collect_outputs.outputs.github_image_name_and_tag }}
       image_name_and_tag: ${{ steps.collect_outputs.outputs.image_name_and_tag }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           echo "VERSIONED_IMAGE_TAG=${{ inputs.sem_ver }}-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
           echo "LATEST_IMAGE_TAG=latest-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
+          echo "MONO_VERSIONED_IMAGE_TAG=${{ inputs.sem_ver }}-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-mono" >> $GITHUB_ENV
+          echo "MONO_LATEST_IMAGE_TAG=latest-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-mono" >> $GITHUB_ENV
+          echo "VANILLA_VERSIONED_IMAGE_TAG=${{ inputs.sem_ver }}-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-vanilla" >> $GITHUB_ENV
+          echo "VANILLA_LATEST_IMAGE_TAG=latest-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-vanilla" >> $GITHUB_ENV
 
       - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
@@ -60,7 +64,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images to Github
+      - name: Build and push Mono Docker images to Github
         uses: docker/build-push-action@v2.9.0
         with:
           context: .
@@ -68,11 +72,12 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }}
           build-args: |
-            GODOT_VERSION=${{ inputs.godot_version }}
+            GODOT_VERSION=mono-${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
 
-      - name: Build and Release Docker images to Dockerhub
+      - name: Build and Release Mono Docker images to Dockerhub
         if: ${{ inputs.release_image }}
         uses: docker/build-push-action@v2.9.0
         with:
@@ -81,16 +86,19 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }}
+            ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }}
             ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_IMAGE_TAG }}
+            ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_LATEST_IMAGE_TAG }}
+            
           build-args: |
-            GODOT_VERSION=${{ inputs.godot_version }}
+            GODOT_VERSION=mono-${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
 
       - name: Collect outputs
         id: collect_outputs
         run: |
-          echo github_image_name_and_tag=ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
-          echo image_name_and_tag=${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
+          echo github_image_name_and_tag=ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
+          echo image_name_and_tag=${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.MONO_VERSIONED_IMAGE_TAG }} >> $GITHUB_OUTPUT
     outputs:
       github_image_name_and_tag: ${{ steps.collect_outputs.outputs.github_image_name_and_tag }}
       image_name_and_tag: ${{ steps.collect_outputs.outputs.image_name_and_tag }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,7 +49,7 @@ jobs:
           echo "VANILLA_VERSIONED_IMAGE_TAG=${{ inputs.sem_ver }}-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-vanilla" >> $GITHUB_ENV
           echo "VANILLA_LATEST_IMAGE_TAG=latest-${{ inputs.godot_version }}${{ env.IMAGE_TAG }}-vanilla" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Mono Docker images to Github
         uses: docker/build-push-action@v6
@@ -76,6 +79,8 @@ jobs:
           build-args: |
             GODOT_VERSION=mono-${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and Release Mono Docker images to Dockerhub
         if: ${{ inputs.release_image }}
@@ -93,6 +98,8 @@ jobs:
           build-args: |
             GODOT_VERSION=mono-${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push Vanilla Docker images to Github
         uses: docker/build-push-action@v6
@@ -105,6 +112,8 @@ jobs:
           build-args: |
             GODOT_VERSION=${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and Release Vanilla Docker images to Dockerhub
         if: ${{ inputs.release_image }}
@@ -120,6 +129,8 @@ jobs:
           build-args: |
             GODOT_VERSION=${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Collect outputs
         id: collect_outputs

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -94,6 +94,33 @@ jobs:
             GODOT_VERSION=mono-${{ inputs.godot_version }}
             RELEASE_NAME=${{ inputs.release_name }}
 
+      - name: Build and push Vanilla Docker images to Github
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VANILLA_VERSIONED_IMAGE_TAG }}
+          build-args: |
+            GODOT_VERSION=${{ inputs.godot_version }}
+            RELEASE_NAME=${{ inputs.release_name }}
+
+      - name: Build and Release Vanilla Docker images to Dockerhub
+        if: ${{ inputs.release_image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VANILLA_VERSIONED_IMAGE_TAG }}
+            ${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ env.VANILLA_LATEST_IMAGE_TAG }}
+            
+          build-args: |
+            GODOT_VERSION=${{ inputs.godot_version }}
+            RELEASE_NAME=${{ inputs.release_name }}
+
       - name: Collect outputs
         id: collect_outputs
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -27,6 +27,12 @@ jobs:
     container:
       image: ${{ matrix.build_image }}
     steps:
+      - name: Show env
+        run: env
+      - name: Show PATH
+        run: echo $PATH
+      - name: Show HOME
+        run: echo $HOME
       - name: Godot
         run: godot --version
       - name: Blender

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -67,7 +67,7 @@ jobs:
         PROJECT_PATH: test_project
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -121,7 +121,7 @@ jobs:
       image: ${{ matrix.build_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Godot
         run: godot --version
+      - name: Blender
+        run: blender --version
       - name: Dotnet
         run: dotnet --version
       - name: Scons
@@ -37,8 +39,8 @@ jobs:
         run: rustup --version
       - name: Rust Toolchains
         run: rustup toolchain list
-      - name: Blender
-        run: blender --version
+      - name: EMSDK
+        run: emsdk list
 
   build_project_linux:
     strategy:

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Show editor settings
         run: |
-          source /etc/profile
+          /opt/setup_editor_settings_version.sh
           cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
@@ -83,7 +83,7 @@ jobs:
 
       - name: Show editor settings
         run: |
-          source /etc/profile
+          /opt/setup_editor_settings_version.sh
           cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
@@ -132,7 +132,7 @@ jobs:
 
       - name: Show editor settings
         run: |
-          source /etc/profile
+          /opt/setup_editor_settings_version.sh
           cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
@@ -178,7 +178,7 @@ jobs:
 
       - name: Show editor settings
         run: |
-          source /etc/profile
+          /opt/setup_editor_settings_version.sh
           cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -74,11 +74,14 @@ jobs:
       - name: Fix paths for Github
         run: setup_github_paths.sh
 
+      - name: Setup Editor Settings Environment
+        run: setup_editor_settings_version.sh
+
       - name: Show environment
         run: env
-
+        
       - name: Show editor settings
-        run: setup_editor_settings_version.sh && cat $GODOT_EDITOR_SETTINGS_PATH
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -125,11 +128,14 @@ jobs:
       - name: Fix paths for Github
         run: setup_github_paths.sh
 
+      - name: Setup Editor Settings Environment
+        run: setup_editor_settings_version.sh
+
       - name: Show environment
         run: env
 
       - name: Show editor settings
-        run: setup_editor_settings_version.sh && cat $GODOT_EDITOR_SETTINGS_PATH
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -27,6 +27,8 @@ jobs:
     container:
       image: ${{ matrix.build_image }}
     steps:
+      - name: Fix paths for Github
+        run: setup_github_paths.sh
       - name: Show env
         run: env
       - name: Show PATH

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -14,6 +14,32 @@ env:
   EXPORT_NAME: omnibuilder_test_project
   PROJECT_PATH: test_project
 jobs:
+  verify_tools:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
+    name: Verify Tools
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.build_image }}
+    steps:
+      - name: Godot
+        run: godot --version
+      - name: Dotnet
+        run: dotnet --version
+      - name: Scons
+        run: scons --version
+      - name: RustUp
+        run: rustup --version
+      - name: Rust Toolchains
+        run: rustup toolchain list
+      - name: Blender
+        run: blender --version
+
   build_project_linux:
     strategy:
       matrix:

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -36,7 +36,9 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat $GODOT_EDITOR_SETTINGS_PATH
+        run: |
+          source /etc/profile
+          cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -80,7 +82,9 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat $GODOT_EDITOR_SETTINGS_PATH
+        run: |
+          source /etc/profile
+          cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -127,7 +131,9 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat $GODOT_EDITOR_SETTINGS_PATH
+        run: |
+          source /etc/profile
+          cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -171,7 +177,9 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat $GODOT_EDITOR_SETTINGS_PATH
+        run: |
+          source /etc/profile
+          cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -13,13 +13,19 @@ on:
 env:
   EXPORT_NAME: omnibuilder_test_project
   PROJECT_PATH: test_project
-
 jobs:
-  build_project_linux-vanilla:
-    name: Build Vanilla Test Project (Linux)
+  build_project_linux:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
+    name: Build Test Project (Linux)
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.build_image }}-vanilla
+      image: ${{ matrix.build_image }}
       env:
         EXPORT_NAME: omnibuilder_test_project
         PROJECT_PATH: test_project
@@ -57,18 +63,23 @@ jobs:
       - name: Linux Build
         run: |
           cd $PROJECT_PATH
-          godot -v --headless --export-release "Linux/X11" ../build/linux/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
+          godot -v --headless --export-release "Linux/X11" ../build/linux/$EXPORT_NAME-${{ inputs.sem_ver }}-${{ matrix.artifact_tag }}.x86_64
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-linux
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.sem_ver }}-linux-${{ matrix.artifact_tag }}
           path: build/linux
 
-  build_project_windows-vanilla:
-    name: Build Vanilla Test Project (Windows Desktop)
+  build_project_windows:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+    name: Build Test Project (Windows Desktop)
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.build_image }}-vanilla
+      image: ${{ matrix.build_image }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -103,104 +114,9 @@ jobs:
       - name: Windows Build
         run: |
           cd $PROJECT_PATH
-          godot -v --headless --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
+          godot -v --headless --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME-${{ inputs.sem_ver }}-${{ matrix.artifact_tag }}.exe
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-windows
-          path: build/windows
-
-  build_project_linux-mono:
-    name: Build Mono Test Project (Linux)
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ inputs.build_image }}-mono
-      env:
-        EXPORT_NAME: omnibuilder_test_project
-        PROJECT_PATH: test_project
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
-      - name: Show environment
-        run: env
-
-      - name: Show editor settings
-        run: |
-          /opt/setup_editor_settings_version.sh
-          cat $GODOT_EDITOR_SETTINGS_PATH
-
-      - name: Prebuild
-        run: |
-          mkdir -v -p build/linux
-          cd $PROJECT_PATH
-          godot -v --headless --import
-
-      - name: Show imported asset directory
-        run: ls -la $PROJECT_PATH/.godot/imported
-
-      - name: Validate that blender files were imported
-        run: |
-          cd $PROJECT_PATH
-          ./validate_imports.sh
-
-      - name: Linux Build
-        run: |
-          cd $PROJECT_PATH
-          godot -v --headless --export-release "Linux/X11" ../build/linux/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-linux
-          path: build/linux
-
-  build_project_windows-mono:
-    name: Build Mono Test Project (Windows Desktop)
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ inputs.build_image }}-mono
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
-      - name: Show environment
-        run: env
-
-      - name: Show editor settings
-        run: |
-          /opt/setup_editor_settings_version.sh
-          cat $GODOT_EDITOR_SETTINGS_PATH
-
-      - name: Prebuild
-        run: |
-          mkdir -v -p build/windows
-          cd $PROJECT_PATH
-          godot -v --headless --import
-
-      - name: Show imported asset directory
-        run: ls -la $PROJECT_PATH/.godot/imported
-
-      - name: Validate that blender files were imported
-        run: |
-          cd $PROJECT_PATH
-          ./validate_imports.sh
-
-      - name: Windows Build
-        run: |
-          cd $PROJECT_PATH
-          godot -v --headless --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-windows
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.sem_ver }}-windows-${{ matrix.artifact_tag }}
           path: build/windows

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -70,9 +70,7 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: |
-          /opt/setup_editor_settings_version.sh
-          cat $GODOT_EDITOR_SETTINGS_PATH
+        run: setup_editor_settings_version.sh && cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -123,9 +121,7 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: |
-          /opt/setup_editor_settings_version.sh
-          cat $GODOT_EDITOR_SETTINGS_PATH
+        run: setup_editor_settings_version.sh && cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -15,11 +15,11 @@ env:
   PROJECT_PATH: test_project
 
 jobs:
-  build_project_linux:
-    name: Build Test Project (Linux)
+  build_project_linux-vanilla:
+    name: Build Vanilla Test Project (Linux)
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.build_image }}
+      image: ${{ inputs.build_image }}-vanilla
       env:
         EXPORT_NAME: omnibuilder_test_project
         PROJECT_PATH: test_project
@@ -36,7 +36,7 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat ~/.config/godot/editor_settings-4.4.tres
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |
@@ -62,11 +62,11 @@ jobs:
           name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-linux
           path: build/linux
 
-  build_project_windows:
-    name: Build Test Project (Windows Desktop)
+  build_project_windows-vanilla:
+    name: Build Vanilla Test Project (Windows Desktop)
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.build_image }}
+      image: ${{ inputs.build_image }}-vanilla
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,7 +80,98 @@ jobs:
         run: env
 
       - name: Show editor settings
-        run: cat ~/.config/godot/editor_settings-4.4.tres
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
+
+      - name: Prebuild
+        run: |
+          mkdir -v -p build/windows
+          cd $PROJECT_PATH
+          godot -v --headless --import
+
+      - name: Show imported asset directory
+        run: ls -la $PROJECT_PATH/.godot/imported
+
+      - name: Validate that blender files were imported
+        run: |
+          cd $PROJECT_PATH
+          ./validate_imports.sh
+
+      - name: Windows Build
+        run: |
+          cd $PROJECT_PATH
+          godot -v --headless --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-windows
+          path: build/windows
+
+  build_project_linux-mono:
+    name: Build Mono Test Project (Linux)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.build_image }}-mono
+      env:
+        EXPORT_NAME: omnibuilder_test_project
+        PROJECT_PATH: test_project
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Fix paths for Github
+        run: setup_github_paths.sh
+
+      - name: Show environment
+        run: env
+
+      - name: Show editor settings
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
+
+      - name: Prebuild
+        run: |
+          mkdir -v -p build/linux
+          cd $PROJECT_PATH
+          godot -v --headless --import
+
+      - name: Show imported asset directory
+        run: ls -la $PROJECT_PATH/.godot/imported
+
+      - name: Validate that blender files were imported
+        run: |
+          cd $PROJECT_PATH
+          ./validate_imports.sh
+
+      - name: Linux Build
+        run: |
+          cd $PROJECT_PATH
+          godot -v --headless --export-release "Linux/X11" ../build/linux/$EXPORT_NAME-${{ inputs.semVer }}.x86_64
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.semVer }}-linux
+          path: build/linux
+
+  build_project_windows-mono:
+    name: Build Mono Test Project (Windows Desktop)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.build_image }}-mono
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Fix paths for Github
+        run: setup_github_paths.sh
+
+      - name: Show environment
+        run: env
+
+      - name: Show editor settings
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
 
       - name: Prebuild
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -101,7 +101,9 @@ jobs:
       matrix:
         include:
           - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
           - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
     name: Build Test Project (Windows Desktop)
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/determine-version.yml
+++ b/.github/workflows/determine-version.yml
@@ -11,7 +11,7 @@ jobs:
     name: Determine build state
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       # Get git version set up
       - name: Fetch all history for all tags and branches
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       sem_ver: ${{ needs.determine_version.outputs.sem_ver }}
-      godot_version: 4.4
+      godot_version: 4.4.1
       release_name: stable
       release_image: false
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,3 +24,12 @@ jobs:
     with:
       sem_ver: ${{ needs.determine_version.outputs.sem_ver }}
       build_image: ${{ needs.build_image.outputs.github_image_name_and_tag }}
+      
+  pr_build_status_green:
+    needs:
+      - build_image
+      - build_projects
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ok!
+        run: echo Ok!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - godot_version: 4.4
             release_name: stable
+          - godot_version: 4.4.1
+            release_name: stable
     needs: determine_version
     uses: ./.github/workflows/build-image.yml
     with:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.0.0]
 ### Added
   - Support 4.4 by @TDogVoid in [#18](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/18), [#19](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/19)
-  - Deprecated [Fock of godot-ci](https://github.com/witchpixels/godot-ci) now based on upstream [abarichello/godot-ci](https://github.com/abarichello/godot-ci)
+  - Deprecated [Fork of godot-ci](https://github.com/witchpixels/godot-ci) now based on upstream [abarichello/godot-ci](https://github.com/abarichello/godot-ci)
 
 ## [2.0.0]
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.0]
 ### Added
   - Support for Non-mono build containers [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
-    - Adds the tags `<semver>-<godot-version><godot release tag>-mono` and `latest-<godot-version><godot release tag>-mono`
+    - Adds the tags `<semver>-<godot-version><godot release tag>-mono` and `latest-<godot-version><godot release tag>-mono` to previous godot-mono builds
   - [x] Adds new container builds that are based on non-mono container tags of [abarichello/godot-ci](https://github.com/abarichello/godot-ci/)
-    - There are tagges as `<semver>-<godot-version><godot release tag>-vanilla` and `latest-<godot-version><godot release tag>-vanilla`
+    - There are tagged as `<semver>-<godot-version><godot release tag>-vanilla` and `latest-<godot-version><godot release tag>-vanilla`
   - Added the following tools to the build container [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
     - Scons
     - Rustup

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,61 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+### Added
+  - Support for Non-mono build containers [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
+    - Adds the tags `<semver>-<godot-version><godot release tag>-mono` and `latest-<godot-version><godot release tag>-mono`
+  - [x] Adds new container builds that are based on non-mono container tags of [abarichello/godot-ci](https://github.com/abarichello/godot-ci/)
+    - There are tagges as `<semver>-<godot-version><godot release tag>-vanilla` and `latest-<godot-version><godot release tag>-vanilla`
+  - Added the following tools to the build container [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
+    - Scons
+    - Rustup
+    - EMSDK
+  
+### Changed
+  - Update `docker-login` and `build-push-action` versions as the old ones used deprecated Github functionality [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
+  - Blender updated to `4.5.1 LTS` [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
+
+
+## [3.0.0]
+### Added
+  - Support 4.4 by @TDogVoid in [#18](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/18), [#19](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/19)
+  - Deprecated [Fock of godot-ci](https://github.com/witchpixels/godot-ci) now based on upstream [abarichello/godot-ci](https://github.com/abarichello/godot-ci)
+
 ## [2.0.0]
 ### Added
- * Support for Godot 4.3
+  - Support for Godot 4.3
 
 ### Removed
- * Support for previous version of Godot from this version onwards
- * fbx2gltf is no longer installed as part of the container as it is redundant in godot 4.3
+  - Support for previous version of Godot from this version onwards
+  - fbx2gltf is no longer installed as part of the container as it is redundant in godot 4.3
 
 
 ## [1.2.2]
 ### Changed
- * Update blender verison to 4.2 in perparation for Godot 4.3
+  - Update blender verison to 4.2 in perparation for Godot 4.3
 
 ## [1.2.1]
 
 ### Fixed
- * Fixed manual release pipeline
+ - Fixed manual release pipeline
 
 ## [1.2.0]
 ### Added
- * Add support for godot 4.2
- * Added a release pipeline to handle new godot versions between actual substantive changes to the container.
+ - Add support for godot 4.2
+ - Added a release pipeline to handle new godot versions between actual substantive changes to the container.
 
 ### Misc
- * Did a bit of refactoring to make the pipelines a little more readable, hopefully.
+ - Did a bit of refactoring to make the pipelines a little more readable, hopefully.
 
 ## [1.1.1]
 
 ### Added
- * Add 4.1.2 and 4.1.3 to release matrix
+ - Add 4.1.2 and 4.1.3 to release matrix
 
 ## [1.1.0]
 
 ### Added
-    * Support for fbx import using FBX2glTF @[Terrence Drumm](https://github.com/TDogVoid)
+  - Support for fbx import using FBX2glTF @[Terrence Drumm](https://github.com/TDogVoid)
 
 ### Changed
-    * Remove a docker login step from the CI pipeline that is both unneeded and will always fail on a PR from anyone but the repo owner.
+  - Remove a docker login step from the CI pipeline that is both unneeded and will always fail on a PR from anyone but the repo owner.
 
 ## [1.0.0]
 
 Initial Release
 
 ### Added
-    * Docker Image that builds off of [aBarichello's godot-ci project](https://github.com/abarichello/godot-ci/) including the following additional tools:
-        * dotnet sdk 6.0
-        * dotnet-gitversion for version management
-        * blender 3.6.0
-        * helper scripts for stamping versions, installing additonal blender versions
-        * helper tools for dealing with path disparity between GitLab and Github runners
-    * A test project to verify the container builds as expected with a semi-automated pass/fail (still kinda needs visual confirmation)
-    * Added release pipeline to push to following godot versions
-        * 4.0.3 stable
-        * 4.1.1 stable
+  - Docker Image that builds off of [aBarichello's godot-ci project](https://github.com/abarichello/godot-ci/) including the following additional tools:
+    - dotnet sdk 6.0
+    - dotnet-gitversion for version management
+    - blender 3.6.0
+    - helper scripts for stamping versions, installing additonal blender versions
+    - helper tools for dealing with path disparity between GitLab and Github runners
+  - A test project to verify the container builds as expected with a semi-automated pass/fail (still kinda needs visual confirmation)
+  - Added release pipeline to push to following godot versions
+    - 4.0.3 stable
+    - 4.1.1 stable
 
+[3.1.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v1.2.2...v2.0.0
 [1.2.2]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v1.2.0...v1.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 RUN apt-get update
 
 # Install Scons for GdExtension Users
-RUN apt-get install scons
+RUN apt-get install -y scons
 
 # Install Rustup for GdRust Users
-RUN apt-get install rustup
+RUN apt-get install -y rustup
 
 # Install emsdk for anyone who needs it for building wasm components
 ADD setup_emsdk.sh /opt/setup_emsdk.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contri
 ARG GODOT_VERSION
 ENV GODOT_VERSION=${GODOT_VERSION}
 
-ADD setup_editor_settings_version.sh /opt/setup_editor_settings_version.sh
-RUN bash /opt/setup_editor_settings_version.sh
+ADD setup_editor_settings_version.sh /opt/scripts/setup_editor_settings_version.sh
+RUN bash /opt/scripts/setup_editor_settings_version.sh
 
 # install dotnet-sdk
 ADD install_dotnet_sdk.sh /opt/scripts/install_dotnet_sdk.sh
@@ -33,8 +33,8 @@ RUN rustup component add rust-src --toolchain nightly
 RUN rustup target add wasm32-unknown-emscripten --toolchain nightly
 
 # Install emsdk for anyone who needs it for building wasm components
-ADD setup_emsdk.sh /opt/setup_emsdk.sh 
-RUN bash /opt/setup_emsdk.sh 
+ADD setup_emsdk.sh /opt/scripts/setup_emsdk.sh 
+RUN bash /opt/scripts/setup_emsdk.sh 
 
 # A tool we use for pulling apart version strings
 RUN apt-get install -y jq
@@ -60,4 +60,4 @@ ADD setup_github_paths.sh /opt/scripts/setup_github_paths.sh
 # Finally, the optional script to stamp versions if you need it
 ADD apply_version_info.sh /opt/scripts/apply_version_info.sh
 
-ENV PATH="/opt/scripts/:${PATH}"
+ENV PATH="/emsdk/upstream/emscripten:/emsdk/node/22.16.0_64bit/bin:/emsdk:/root/.cargo/bin:/opt/scripts:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get install scons
 # Install Rustup for GdRust Users
 RUN apt-get install rustup
 
+# Install emsdk for anyone who needs it for building wasm components
+ADD setup_emsdk.sh /opt/setup_emsdk.sh 
+RUN bash /opt/setup_emsdk.sh 
+
 # A tool we use for pulling apart version strings
 RUN apt-get install -y jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,8 @@ LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contri
 
 ARG GODOT_VERSION
 
-RUN echo "${GODOT_VERSION}"
 ADD setup_editor_settings_version.sh /opt/setup_editor_settings_version.sh
 RUN bash /opt/setup_editor_settings_version.sh
-RUN echo "Godot Settings file version is ${GODOT_EDITOR_SETTINGS_VERSION}"
-RUN echo "Godot Settings file path is ${GODOT_EDITOR_SETTINGS_PATH}"
 
 # install dotnet-sdk
 ADD install_dotnet_sdk.sh /opt/scripts/install_dotnet_sdk.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 RUN apt-get update
 
 # Some Common tool dependencies
-RUN apt-get install -y xz-utils curl
+RUN apt-get install -y xz-utils curl build-essential
 
 # Install Scons for GdExtension Users
 RUN apt-get install -y scons

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y scons
 
 # Install Rustup for GdRust Users
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/home/github/.cargo/bin:/root/.cargo/bin:${PATH}"
 
 # Install wasm toolchain for rust web exports
 RUN rustup toolchain install nightly
@@ -35,6 +36,7 @@ RUN rustup target add wasm32-unknown-emscripten --toolchain nightly
 # Install emsdk for anyone who needs it for building wasm components
 ADD setup_emsdk.sh /opt/scripts/setup_emsdk.sh 
 RUN bash /opt/scripts/setup_emsdk.sh 
+ENV PATH="/emsdk/upstream/emscripten:/emsdk/node/22.16.0_64bit/bin:/emsdk:${PATH}"
 
 # A tool we use for pulling apart version strings
 RUN apt-get install -y jq
@@ -60,4 +62,4 @@ ADD setup_github_paths.sh /opt/scripts/setup_github_paths.sh
 # Finally, the optional script to stamp versions if you need it
 ADD apply_version_info.sh /opt/scripts/apply_version_info.sh
 
-ENV PATH="/emsdk/upstream/emscripten:/emsdk/node/22.16.0_64bit/bin:/emsdk:/root/.cargo/bin:/opt/scripts:${PATH}"
+ENV PATH="/opt/scripts:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 
 RUN apt-get update
 
+# xz utils are needed for a bunch of stuff
+RUN apt-get install -y xz-utils
+
 # Install Scons for GdExtension Users
 RUN apt-get install -y scons
 
@@ -27,7 +30,6 @@ RUN apt-get install -y jq
 
 # install the dependencies for blender, we will use the one installed via downloads
 RUN apt-get install -y xorg
-RUN apt-get install -y xz-utils
 RUN apt-get install -y blender
 
 # install blender and also setup blender's path in editor settings so that you can use the inbuilt blender importer

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contri
 ARG GODOT_VERSION
 
 RUN echo "${GODOT_VERSION}"
-RUN echo export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$(echo $GODOT_VERSION | cut -d '.' -f 1).$(echo $GODOT_VERSION | cut -d '.' -f 2).tres" >> /etc/profile
+ADD setup_editor_settings_version.sh /opt/setup_editor_settings_version.sh
+RUN bash /opt/setup_editor_settings_version.sh
 RUN source /etc/profile
-RUN cat /etc/profile
-RUN echo "Godot Settings file version is $GODOT_EDITOR_SETTINGS_VERSION"
-RUN echo "Godot Settings file path is $GODOT_EDITOR_SETTINGS_PATH"
+RUN echo "Godot Settings file version is ${GODOT_EDITOR_SETTINGS_VERSION}"
+RUN echo "Godot Settings file path is ${GODOT_EDITOR_SETTINGS_PATH}"
 
 # install dotnet-sdk
 ADD install_dotnet_sdk.sh /opt/scripts/install_dotnet_sdk.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ARG GODOT_VERSION
 RUN echo "${GODOT_VERSION}"
 ADD setup_editor_settings_version.sh /opt/setup_editor_settings_version.sh
 RUN bash /opt/setup_editor_settings_version.sh
-RUN source /etc/profile
 RUN echo "Godot Settings file version is ${GODOT_EDITOR_SETTINGS_VERSION}"
 RUN echo "Godot Settings file path is ${GODOT_EDITOR_SETTINGS_PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,15 @@ ARG RELEASE_NAME="stable"
 FROM barichello/godot-ci:${GODOT_VERSION}
 LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contributors"
 
+ARG GODOT_VERSION
+
+RUN echo "${GODOT_VERSION}"
+RUN echo export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$(echo $GODOT_VERSION | cut -d '.' -f 1).$(echo $GODOT_VERSION | cut -d '.' -f 2).tres" >> /etc/profile
+RUN source /etc/profile
+RUN cat /etc/profile
+RUN echo "Godot Settings file version is $GODOT_EDITOR_SETTINGS_VERSION"
+RUN echo "Godot Settings file path is $GODOT_EDITOR_SETTINGS_PATH"
+
 # install dotnet-sdk
 ADD install_dotnet_sdk.sh /opt/scripts/install_dotnet_sdk.sh
 RUN bash /opt/scripts/install_dotnet_sdk.sh
@@ -12,8 +21,8 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 
 RUN apt-get update
 
-# xz utils are needed for a bunch of stuff
-RUN apt-get install -y xz-utils
+# Some Common tool dependencies
+RUN apt-get install -y xz-utils curl
 
 # Install Scons for GdExtension Users
 RUN apt-get install -y scons

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN apt-get install -y scons
 # Install Rustup for GdRust Users
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 
+# Install wasm toolchain for rust web exports
+RUN rustup toolchain install nightly
+RUN rustup component add rust-src --toolchain nightly
+RUN rustup target add wasm32-unknown-emscripten --toolchain nightly
+
 # Install emsdk for anyone who needs it for building wasm components
 ADD setup_emsdk.sh /opt/setup_emsdk.sh 
 RUN bash /opt/setup_emsdk.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM barichello/godot-ci:${GODOT_VERSION}
 LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contributors"
 
 ARG GODOT_VERSION
+ENV GODOT_VERSION=${GODOT_VERSION}
 
 ADD setup_editor_settings_version.sh /opt/setup_editor_settings_version.sh
 RUN bash /opt/setup_editor_settings_version.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y xz-utils
 RUN apt-get install -y blender
 
 # install blender and also setup blender's path in editor settings so that you can use the inbuilt blender importer
-ENV BLENDER_VERSION="4.1.1"
+ENV BLENDER_VERSION="4.5.1"
 
 ADD install_blender.sh /opt/scripts/install_blender.sh
 RUN bash /opt/scripts/install_blender.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,6 @@ ENV PATH="/opt/blender:${PATH}"
 ADD setup_blender_editor_path.sh /opt/scripts/setup_blender_editor_path.sh
 RUN bash /opt/scripts/setup_blender_editor_path.sh
 
-# Some paths produced in the image are incorrect
-ADD setup_templates.sh /opt/scripts/setup_templates.sh
-RUN bash /opt/scripts/setup_templates.sh
-
 # This script is there to fixup paths for github runners, which annoyingly 
 # seem to nuke the home dir we preconfigured in previous versions.
 ADD setup_github_paths.sh /opt/scripts/setup_github_paths.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 
 RUN apt-get update
 
+# Install Scons for GdExtension Users
+RUN apt-get install scons
+
+# Install Rustup for GdRust Users
+RUN apt-get install rustup
+
 # A tool we use for pulling apart version strings
 RUN apt-get install -y jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GODOT_VERSION="4.4"
 ARG RELEASE_NAME="stable"
 
-FROM barichello/godot-ci:mono-${GODOT_VERSION}
+FROM barichello/godot-ci:${GODOT_VERSION}
 LABEL author="https://github.com/witchpixels/godot4-3d-omnibuilder/graphs/contributors"
 
 # install dotnet-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update
 RUN apt-get install -y scons
 
 # Install Rustup for GdRust Users
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 
 # Install emsdk for anyone who needs it for building wasm components
 ADD setup_emsdk.sh /opt/setup_emsdk.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update
 RUN apt-get install -y scons
 
 # Install Rustup for GdRust Users
-RUN apt-get install -y rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Install emsdk for anyone who needs it for building wasm components
 ADD setup_emsdk.sh /opt/setup_emsdk.sh 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -50,7 +50,7 @@ jobs:
           godot -v --headless --export-release "Linux/X11" build/linux/$EXPORT_NAME.x86_64
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-linux
           path: build/linux
@@ -62,7 +62,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -73,10 +73,10 @@ jobs:
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
-          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.x86_64
+          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.exe
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-windows
           path: build/windows
@@ -102,7 +102,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -115,7 +115,7 @@ jobs:
           godot -v --headless --export-release "Linux/X11" build/linux/$EXPORT_NAME.x86_64
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-linux
           path: build/linux
@@ -127,7 +127,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -137,10 +137,10 @@ jobs:
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
-          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.x86_64
+          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.exe
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-windows
           path: build/windows
@@ -169,7 +169,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -182,7 +182,7 @@ jobs:
           godot -v --headless --export-release "Linux/X11" build/linux/$EXPORT_NAME.x86_64
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-linux
           path: build/linux
@@ -194,7 +194,7 @@ jobs:
       image: witchpixels/godot4-omnibuilder3d:latest-4.1.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -205,10 +205,10 @@ jobs:
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
-          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.x86_64
+          godot -v --headless --export-release "Windows Desktop" build/windows/$EXPORT_NAME.exe
           
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-windows
           path: build/windows

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Godot4 3d Omnibuilder Image
-Tired of fussing around dependencies with the godot-ci container? Tired of C# feeling like a second class citizen? Take heart! the 3d Omnibuilder is here to help!
+Tired of fussing around dependencies with the godot-ci container? Tired of C# feeling like a second class citizen? Frustrated with fiddling with Dockerfiles just so your GDExtension can compile? Take heart! the 3d Omnibuilder is here to help!
 
 Most of this is based on the work done on the work done by [aBarichello's godot-ci project](https://github.com/abarichello/godot-ci/), but what I wanted was a *highly* opinionated, low configuration, turnkey build image. Ideally I just wanted a build script that pulls the repo and runs a single command to build per platform.
 
 ## What does it do
 The image here extends `barichello/godot-ci`'s mono image, and does a few things:
- 1. Installs dotnet sdk 6.0
- 2. Install blender
+ 1. Installs dotnet sdk 8.0 and 9.0
+ 2. Install blender's latest LTS version
  3. Sets the blender path in EditorSettings
  5. Install's gitversion and provides a script, `apply_version_info.sh` which will stamp Full Sever into `application/config/version` in project settings as well as wherever makes sense in export_presets.cfg.
+
+ The container also contains and install of `Scons` `Rustup` and `EMSDK` Though if you are using rust, I recommend using `rustup`'s self-update command before compiling to ensure that you have the version of the toolchain that you need for your project.
 
 ## Usage
 
@@ -38,11 +40,9 @@ jobs:
         with:
           lfs: true
 
+      # You only need this for Github Actions, Gitlab works out of the box
       - name: Fix paths for Github
         run: setup_github_paths.sh
-
-      - name: Import assets
-        run: godot -v --headless --import
 
       - name: Linux Build
         run: |
@@ -66,11 +66,9 @@ jobs:
         with:
           lfs: true
 
+      # You only need this for Github Actions, Gitlab works out of the box
       - name: Fix paths for Github
         run: setup_github_paths.sh
-
-      - name: Import assets
-        run: godot -v --headless --import
 
       - name: Windows Build
         run: |
@@ -108,14 +106,8 @@ jobs:
         with:
           lfs: true
 
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
       - name: Install Blender
         run: install_blender.sh 3.6.2
-
-      - name: Import assets
-        run: godot -v --headless --import
 
       - name: Linux Build
         run: |
@@ -139,14 +131,8 @@ jobs:
         with:
           lfs: true
 
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
       - name: Install Blender
         run: install_blender.sh 3.6.2
-
-      - name: Import assets
-        run: godot -v --headless --import
 
       - name: Windows Build
         run: |
@@ -187,12 +173,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
-      - name: Import assets
-        run: godot -v --headless --import
-
       - name: Stamp Versions
         run: apply_version_info.sh
 
@@ -218,11 +198,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Fix paths for Github
-        run: setup_github_paths.sh
-
-      - name: Import assets
-        run: godot -v --headless --import
 
       - name: Stamp Versions
         run: apply_version_info.sh

--- a/apply_version_info.sh
+++ b/apply_version_info.sh
@@ -6,9 +6,9 @@ if [[ -f "GitVersion.yml" || -f "../GitVersion.yml" ]]; then
 
     echo "We need to do a fetch here because normally we don't have tags which gitversion needs to evaluate. Don't panic, please."
     if [[ -f "GitVersion.yml" ]]; then
-        git config --global --add safe.directory $(pwd)
+        git config --global --add safe.directory "$(pwd)"
     elif [[ -f "../GitVersion.yml" ]]; then
-        git config --global --add safe.directory "$(dirname $(pwd))"
+        git config --global --add safe.directory "$(dirname "$(pwd)")"
     fi
     git fetch --prune --unshallow || echo "Looks like that was unneeded... oh well!"
 

--- a/apply_version_info.sh
+++ b/apply_version_info.sh
@@ -14,8 +14,11 @@ if [[ -f "GitVersion.yml" || -f "../GitVersion.yml" ]]; then
 
 
     echo "Running gitversion to retrieve FullSemVer and AssemblySemVer"
-    export SEMVER=$(dotnet-gitversion | jq .FullSemVer)
-    export ASSEMBLY_SEMVER=$(dotnet-gitversion | jq .AssemblySemVer)
+    SEMVER=$(dotnet-gitversion | jq .FullSemVer)
+    export SEMVER
+    
+    ASSEMBLY_SEMVER=$(dotnet-gitversion | jq .AssemblySemVer)
+    export ASSEMBLY_SEMVER
 
     echo "Stamp version $SEMVER in project"
     cat ./project.godot | sed "/^config\\/version=/s/=.*/=$SEMVER/" > ./project.godot.2

--- a/install_blender.sh
+++ b/install_blender.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 DESIRED_BLENDER_VERSION=$1
 
 if [[ -z "$DESIRED_BLENDER_VERSION" ]]; then
@@ -10,7 +10,7 @@ fi
 
 BLENDER_URL_ROOT=${DESIRED_BLENDER_VERSION%.*}
 
-wget -nv https://download.blender.org/release/Blender${BLENDER_URL_ROOT}/blender-${DESIRED_BLENDER_VERSION}-linux-x64.tar.xz
-tar -xJf ./blender-${DESIRED_BLENDER_VERSION}-linux-x64.tar.xz
+wget -nv https://download.blender.org/release/Blender"${BLENDER_URL_ROOT}"/blender-"${DESIRED_BLENDER_VERSION}"-linux-x64.tar.xz
+tar -xJf ./blender-"${DESIRED_BLENDER_VERSION}"-linux-x64.tar.xz
 
-mv ./blender-${DESIRED_BLENDER_VERSION}-linux-x64 /opt/blender
+mv ./blender-"${DESIRED_BLENDER_VERSION}"-linux-x64 /opt/blender

--- a/setup_blender_editor_path.sh
+++ b/setup_blender_editor_path.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
+
+# shellcheck source=/etc/profile
 source /etc/profile
 godot -v -e --quit --headless
 
-echo $(which blender)
+which blender
 echo "EDITOR SETTINGS BEFORE ---------------------------------"
 cat "${GODOT_EDITOR_SETTINGS_PATH}"
 echo "-------------------------------------------------------"
 
-echo "filesystem/import/blender/rpc_port = 6011" >> "${GODOT_EDITOR_SETTINGS_PATH}"
-echo "filesystem/import/blender/rpc_server_uptime = 500" >> "${GODOT_EDITOR_SETTINGS_PATH}"
-echo "filesystem/import/blender/blender_path = \"$(which blender)\"" >> "${GODOT_EDITOR_SETTINGS_PATH}"
+{
+    echo "filesystem/import/blender/rpc_port = 6011"
+    echo "filesystem/import/blender/rpc_server_uptime = 500"
+    echo "filesystem/import/blender/blender_path = \"$(which blender)\"" 
+} >> "${GODOT_EDITOR_SETTINGS_PATH}"
 
 echo "EDITOR SETTINGS AFTER ---------------------------------"
 cat "${GODOT_EDITOR_SETTINGS_PATH}"

--- a/setup_blender_editor_path.sh
+++ b/setup_blender_editor_path.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /etc/profile
+source /etc/bash.bashrc
 godot -v -e --quit --headless
 
 echo $(which blender)

--- a/setup_blender_editor_path.sh
+++ b/setup_blender_editor_path.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-
+source /etc/profile
 godot -v -e --quit --headless
 
 echo $(which blender)
 echo "EDITOR SETTINGS BEFORE ---------------------------------"
-cat /root/.config/godot/editor_settings-4.4.tres
+cat "${GODOT_EDITOR_SETTINGS_PATH}"
 echo "-------------------------------------------------------"
 
-echo "filesystem/import/blender/rpc_port = 6011" >> /root/.config/godot/editor_settings-4.4.tres
-echo "filesystem/import/blender/rpc_server_uptime = 500" >> /root/.config/godot/editor_settings-4.4.tres
-echo "filesystem/import/blender/blender_path = \"$(which blender)\"" >> /root/.config/godot/editor_settings-4.4.tres
+echo "filesystem/import/blender/rpc_port = 6011" >> "${GODOT_EDITOR_SETTINGS_PATH}"
+echo "filesystem/import/blender/rpc_server_uptime = 500" >> "${GODOT_EDITOR_SETTINGS_PATH}"
+echo "filesystem/import/blender/blender_path = \"$(which blender)\"" >> "${GODOT_EDITOR_SETTINGS_PATH}"
 
 echo "EDITOR SETTINGS AFTER ---------------------------------"
-cat /root/.config/godot/editor_settings-4.4.tres
+cat "${GODOT_EDITOR_SETTINGS_PATH}"
 echo "-------------------------------------------------------"

--- a/setup_blender_editor_path.sh
+++ b/setup_blender_editor_path.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /etc/bash.bashrc
+source /etc/profile
 godot -v -e --quit --headless
 
 echo $(which blender)

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+MONO_PREFIX="mono-"
+GD_VERSION=${GODOT_VERSION#"$MONO_PREFIX"}
+echo "Your Godot engine version is $GD_VERSION..."
+EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1).$(echo $GD_VERSION | cut -d '.' -f 2)"
+if [[ "$(echo $GD_VERSION | cut -d '.' -f 2)" == "0" ]] 
+then
+    EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1)"
+fi
+
+GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
+
+echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
+echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
+echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -8,7 +8,7 @@ then
     EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1)"
 fi
 
-GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
+export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
 echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -9,7 +9,16 @@ then
 fi
 
 export GODOT_ENGINE_VERSION=${GD_VERSION}
-export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
+
+# Add GODOT_ENGINE_VERSION and GODOT_EDITOR_SETTINGS_PATH to Github Env if it exists
+if [[ ! -z "$GITHUB_ENV" ]]
+then
+    export GODOT_EDITOR_SETTINGS_PATH="$HOME/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
+    {
+        echo "GODOT_ENGINE_VERSION=${GD_VERSION}"
+        echo "GODOT_EDITOR_SETTINGS_PATH=$GODOT_EDITOR_SETTINGS_PATH" 
+    }>> "$GITHUB_ENV"
+fi
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
 

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -11,5 +11,5 @@ fi
 GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
-echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/bash.bashrc
-echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/bash.bashrc
+echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
+echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -2,10 +2,10 @@
 MONO_PREFIX="mono-"
 GD_VERSION=${GODOT_VERSION#"$MONO_PREFIX"}
 echo "Your Godot engine version is $GD_VERSION..."
-EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1).$(echo $GD_VERSION | cut -d '.' -f 2)"
-if [[ "$(echo $GD_VERSION | cut -d '.' -f 2)" == "0" ]] 
+EDITOR_SETTINGS_VERSION="$(echo "$GD_VERSION" | cut -d '.' -f 1).$(echo "$GD_VERSION" | cut -d '.' -f 2)"
+if [[ "$(echo "$GD_VERSION" | cut -d '.' -f 2)" == "0" ]] 
 then
-    EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1)"
+    EDITOR_SETTINGS_VERSION="$(echo "$GD_VERSION" | cut -d '.' -f 1)"
 fi
 
 export GODOT_ENGINE_VERSION=${GD_VERSION}
@@ -13,11 +13,11 @@ export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_S
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
 
-if [ -z $(grep "export GODOT_ENGINE_VERSION=${GD_VERSION}" "/etc/profile") ]
+if ! grep -q "export GODOT_ENGINE_VERSION=${GD_VERSION}" "/etc/profile"
 then
     echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
 fi
-if [ -z $(grep "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" "/etc/profile") ]
+if ! grep -q "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" "/etc/profile"
 then
     echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile
 fi

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -8,8 +8,16 @@ then
     EDITOR_SETTINGS_VERSION="$(echo $GD_VERSION | cut -d '.' -f 1)"
 fi
 
+export GODOT_ENGINE_VERSION=${GD_VERSION}
 export GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
-echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
-echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile
+
+if [ -z $(grep "export GODOT_ENGINE_VERSION=${GD_VERSION}" "/etc/profile") ]
+then
+    echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
+fi
+if [ -z $(grep "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" "/etc/profile") ]
+then
+    echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile
+fi

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -8,25 +8,35 @@ then
     EDITOR_SETTINGS_VERSION="$(echo "$GD_VERSION" | cut -d '.' -f 1)"
 fi
 
+if [[ -z "$HOME" ]]
+then
+    echo "HOME is not set, setting it to /root and exporting..."
+    HOME="/root"
+    export HOME
+fi
+
 export GODOT_ENGINE_VERSION=${GD_VERSION}
+
+echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
+export GODOT_EDITOR_SETTINGS_PATH="$HOME/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
 
 # Add GODOT_ENGINE_VERSION and GODOT_EDITOR_SETTINGS_PATH to Github Env if it exists
 if [[ ! -z "$GITHUB_ENV" ]]
 then
-    export GODOT_EDITOR_SETTINGS_PATH="$HOME/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
     {
         echo "GODOT_ENGINE_VERSION=${GD_VERSION}"
         echo "GODOT_EDITOR_SETTINGS_PATH=$GODOT_EDITOR_SETTINGS_PATH" 
     }>> "$GITHUB_ENV"
 fi
 
-echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
 
 if ! grep -q "export GODOT_ENGINE_VERSION=${GD_VERSION}" "/etc/profile"
 then
+    echo "Save engine version ${GD_VERSION} to /etc/profile"
     echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
 fi
 if ! grep -q "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" "/etc/profile"
 then
+    echo "Save editor path ${GODOT_EDITOR_SETTINGS_PATH} to /etc/profile"
     echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile
 fi

--- a/setup_editor_settings_version.sh
+++ b/setup_editor_settings_version.sh
@@ -11,5 +11,5 @@ fi
 GODOT_EDITOR_SETTINGS_PATH="/root/.config/godot/editor_settings-$EDITOR_SETTINGS_VERSION.tres"
 
 echo "Setting editor settings path as $GODOT_EDITOR_SETTINGS_PATH"
-echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/profile
-echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/profile
+echo "export GODOT_ENGINE_VERSION=${GD_VERSION}" >> /etc/bash.bashrc
+echo "export GODOT_EDITOR_SETTINGS_PATH=${GODOT_EDITOR_SETTINGS_PATH}" >> /etc/bash.bashrc

--- a/setup_emsdk.sh
+++ b/setup_emsdk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk
+cd emsdk || exit 1
 ./emsdk install latest
 ./emsdk activate latest

--- a/setup_emsdk.sh
+++ b/setup_emsdk.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest
+./emsdk activate latest

--- a/setup_github_paths.sh
+++ b/setup_github_paths.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
-mkdir -pv /github/home/
-cp -Lrvu /root/* /github/home/
+if [[ "$HOME" == "/root" ]] 
+then
+    echo "Current user's ($USER) home folder is /root... nothing to do."
+    exit 0
+fi
+
+mkdir -pv "$HOME"
+cp -Lrvu /root/. "$HOME"
 chown -R "$USER" "$HOME"

--- a/setup_github_paths.sh
+++ b/setup_github_paths.sh
@@ -6,5 +6,5 @@ then
 fi
 
 mkdir -pv "$HOME"
-cp -Lrvu /root/. "$HOME"
+cp -Lrv /root/. "$HOME"
 chown -R "$USER" "$HOME"

--- a/setup_github_paths.sh
+++ b/setup_github_paths.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 mkdir -pv /github/home/
+cp -Lrv /root/.cargo /github/home/
 cp -Lrv /root/.local /github/home/
 cp -Lrv /root/.config /github/home/

--- a/setup_github_paths.sh
+++ b/setup_github_paths.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 mkdir -pv /github/home/
-cp -Lrv /root/.cargo /github/home/
-cp -Lrv /root/.local /github/home/
-cp -Lrv /root/.config /github/home/
+cp -Lrvu /root/* /github/home/
+chown -R "$USER" "$HOME"

--- a/setup_templates.sh
+++ b/setup_templates.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-echo "Using Godot Version $GODOT_VERSION.$RELEASE_NAME"
-
-ls -la /root/.local/share/godot/templates/
-
-# fix template directories, which are wrong in the source image for some reason.
-mkdir -v -p /root/.local/share/godot/export_templates
-cp -rv /root/.local/share/godot/templates/* /root/.local/share/godot/export_templates/
-ls -la /root/.local/share/godot/export_templates/

--- a/test_project/test_project.csproj
+++ b/test_project/test_project.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.4.0">
+<Project Sdk="Godot.NET.Sdk/4.4.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>


### PR DESCRIPTION
Fixes #20 

- [x] Adds the tags `<semver>-<godot-version><godot release tag>-mono` and `latest-<godot-version><godot release tag>-mono`
- [x] Adds new container builds that are based on non-mono container tags of [abarichello/godot-ci](https://github.com/abarichello/godot-ci/)
  - There are tagges as `<semver>-<godot-version><godot release tag>-vanilla` and `latest-<godot-version><godot release tag>-vanilla`
- [x] Update `docker-login` and `build-push-action` versions as the old ones used deprecated Github functionality
- [x] Add Scons to all built containers to better support users of GDExtensions using C or C++
- [x] Add RustUp to all build containers to better support users of GDRust for their 
GDExtensions
  - **NOTE** You will still need to install your preferred toolchain in your build process since the needs of WASM exports and desktop exports are different. Also you'll prbably want to update that more frequently than we release containers.
- [x] Update Blender to Latest LTS
- [x] Add EMSDK for Wasm builds of native code (needed for gdrust to export to wasm and kind of annoying to install)
- [x] Add Environment Variables for `GODOT_VERSION` and `GODOT_EDITOR_SETTINGS_PATH` which tell you the version that this container was built with at runtime, and allows you to find the correct editor settings file without manually setting the value.
