### PR TITLE
Support for rust windows builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0]
+### Added
+  - Dependencies for building for windows desktop using gd-rust
+
 ## [3.1.0]
 ### Added
   - Support for Non-mono build containers [#21](https://github.com/witchpixels/godot4-3d-omnibuilder/pull/21)
@@ -81,6 +85,7 @@ Initial Release
     - 4.0.3 stable
     - 4.1.1 stable
 
+[3.2.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/witchpixels/godot4-3d-omnibuilder/compare/v1.2.2...v2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH="/github/home/.dotnet/tools:/root/.dotnet/tools:${PATH}"
 RUN apt-get update
 
 # Some Common tool dependencies
-RUN apt-get install -y xz-utils curl build-essential
+RUN apt-get install -y xz-utils curl build-essential mingw-w64
 
 # Install Scons for GdExtension Users
 RUN apt-get install -y scons
@@ -27,6 +27,9 @@ RUN apt-get install -y scons
 # Install Rustup for GdRust Users
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/home/github/.cargo/bin:/root/.cargo/bin:${PATH}"
+
+# Setup support for windows builds
+RUN rustup target add x86_64-pc-windows-gnu
 
 # Install wasm toolchain for rust web exports
 RUN rustup toolchain install nightly


### PR DESCRIPTION
Add mingw64 linker and add rust target for win64. I assume this is also needed if you are using C gdextensions

+semver: minor