### PR TITLE
Make symlink instead of copying

### DIFF
--- a/.github/workflows/build-projects-repo.yml
+++ b/.github/workflows/build-projects-repo.yml
@@ -1,0 +1,168 @@
+name: Verify Test Projects (With Repo Scripts)
+on:
+  workflow_dispatch:
+    inputs:
+      sem_ver:
+        description: "Semantic version of this repository"
+        required: true
+        type: string
+        default: "manual-trigger"
+      build_image:
+        description: The image to build the projects against
+        required: true
+        type: string
+        default: "witchpixels/godot4-omnibuilder3d:latest-4.5.1"
+env:
+  EXPORT_NAME: omnibuilder_test_project
+  PROJECT_PATH: test_project
+jobs:
+  verify_tools:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
+    name: Verify Tools
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.build_image }}
+    steps:
+      - name: Show env
+        run: env
+      - name: Show PATH
+        run: echo $PATH
+      - name: Show HOME
+        run: echo $HOME
+      - name: Godot
+        run: godot --version
+      - name: Blender
+        run: blender --version
+      - name: Dotnet
+        run: dotnet --version
+      - name: Scons
+        run: scons --version
+      - name: RustUp
+        run: rustup --version
+      - name: Rust Toolchains
+        run: rustup toolchain list
+      - name: EMSDK
+        run: emsdk list
+
+  build_project_linux:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
+    name: Build Test Project (Linux)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.build_image }}
+      env:
+        EXPORT_NAME: omnibuilder_test_project
+        PROJECT_PATH: test_project
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Diff with container
+        run: diff ./setup_github_paths.sh /opt/scripts/setup_github_paths.sh || true
+
+      - name: Fix paths for Github
+        run: ./setup_github_paths.sh
+
+      - name: Setup Editor Settings Environment
+        run: setup_editor_settings_version.sh
+
+      - name: Show environment
+        run: env
+
+      - name: Show editor settings
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
+
+      - name: Prebuild
+        run: |
+          mkdir -v -p build/linux
+          cd $PROJECT_PATH
+          godot -v --headless --import
+
+      - name: Show imported asset directory
+        run: ls -la $PROJECT_PATH/.godot/imported
+
+      - name: Validate that blender files were imported
+        run: |
+          cd $PROJECT_PATH
+          ./validate_imports.sh
+
+      - name: Linux Build
+        run: |
+          cd $PROJECT_PATH
+          godot -v --headless --export-release "Linux/X11" ../build/linux/$EXPORT_NAME-${{ inputs.sem_ver }}-${{ matrix.artifact_tag }}.x86_64
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.sem_ver }}-linux-${{ matrix.artifact_tag }}
+          path: build/linux
+
+  build_project_windows:
+    strategy:
+      matrix:
+        include:
+          - build_image: ${{ inputs.build_image }}-vanilla
+            artifact_tag: vanilla
+          - build_image: ${{ inputs.build_image }}-mono
+            artifact_tag: mono
+    name: Build Test Project (Windows Desktop)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.build_image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Diff with container
+        run: diff ./setup_github_paths.sh /opt/scripts/setup_github_paths.sh || true
+
+      - name: Fix paths for Github
+        run: ./setup_github_paths.sh
+
+      - name: Setup Editor Settings Environment
+        run: setup_editor_settings_version.sh
+
+      - name: Show environment
+        run: env
+
+      - name: Show editor settings
+        run: cat $GODOT_EDITOR_SETTINGS_PATH
+
+      - name: Prebuild
+        run: |
+          mkdir -v -p build/windows
+          cd $PROJECT_PATH
+          godot -v --headless --import
+
+      - name: Show imported asset directory
+        run: ls -la $PROJECT_PATH/.godot/imported
+
+      - name: Validate that blender files were imported
+        run: |
+          cd $PROJECT_PATH
+          ./validate_imports.sh
+
+      - name: Windows Build
+        run: |
+          cd $PROJECT_PATH
+          godot -v --headless --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME-${{ inputs.sem_ver }}-${{ matrix.artifact_tag }}.exe
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-${{ inputs.sem_ver }}-windows-${{ matrix.artifact_tag }}
+          path: build/windows

--- a/setup_github_paths.sh
+++ b/setup_github_paths.sh
@@ -6,5 +6,6 @@ then
 fi
 
 mkdir -pv "$HOME"
-cp -Lrv /root/. "$HOME"
+ln -sv /root/* "$HOME"
+ln -sv /root/.* "$HOME"
 chown -R "$USER" "$HOME"


### PR DESCRIPTION
Fixes #30.

Made an alternate workflow tests using the script from the repo instead of the container. Symlink works. I could also make it a hard link, but it shouldn't matter too much.

Besides this, I also tried removing the verbose option from the copy. This still causes a storage space issue with GitHub? I also tried a file move, but it isn't trivial to move things out from the container.
