### PR TITLE
Remove 4.5.2 from release martix, as it is in rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - godot_version: 4.4.1
             release_name: stable
-          - godot_version: 4.5.2
+          - godot_version: 4.5.1
             release_name: stable
           - godot_version: 4.6.1
             release_name: stable


### PR DESCRIPTION
4.5.2 is in RC, but was mistakenly added to stable build roster in re…